### PR TITLE
psys: Apply FLIP_ENDIAN_HACK when __BYTE_ORDER__ is defined.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,11 +5,6 @@ sdl2_dep = dependency('SDL2')
 sdl2main_dep = dependency('SDL2main', required: false)
 m_lib = meson.get_compiler('c').find_library('m', required: false)
 
-# Flip p-system endian (XXX should only be required on little-endian systems)
-add_project_arguments(
-    '-DFLIP_ENDIAN_HACK',
-    language: ['c', 'cpp']
-)
 if get_option('psys_debugger')
     add_project_arguments(
         '-DPSYS_DEBUGGER',

--- a/src/psys/psys_helpers.h
+++ b/src/psys/psys_helpers.h
@@ -23,12 +23,12 @@ extern "C" {
  */
 #define W(base, ofs) ((base) + ((ofs)*2))
 #endif
-#ifdef FLIP_ENDIAN_HACK
-/* Flip endian */
-#define F(x) psys_flip_endian(x)
-#else
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 /* Don't flip endian */
 #define F(x) (x)
+#else
+/* Flip endian */
+#define F(x) psys_flip_endian(x)
 #endif
 
 /* Sign extend byte */

--- a/src/test/set_tests.c
+++ b/src/test/set_tests.c
@@ -10,13 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef FLIP_ENDIAN_HACK
-/* Flip endian */
-#define F(x) psys_flip_endian(x)
-#else
-/* Don't flip endian */
-#define F(x) (x)
-#endif
 /* Read from set (in native endian) */
 #define I(x, y) F((x)[(y)])
 /* Write to set (in native endian) */


### PR DESCRIPTION
This will automatically apply the hack macro on Linux without touching the build files.