### PR TITLE
Allow building with system GL headers with USE_SYSGL macro.

### DIFF
--- a/src/glutil.h
+++ b/src/glutil.h
@@ -7,7 +7,12 @@
 #ifndef H_GLUTIL
 #define H_GLUTIL
 
+#ifdef USE_SYSGL
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#else
 #include <glxw/glxw_es3.h>
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/sundog.c
+++ b/src/sundog.c
@@ -877,9 +877,11 @@ int main(int argc, char **argv)
         psys_panic("Unable to create context: %s\n", SDL_GetError());
     }
 
+#ifndef USE_SYSGL
     if (!load_es3_procs()) {
         psys_panic("Unable to load OpenGL ES 2/3 functions.\n");
     }
+#endif
     printf("GL version: %s\n", glGetString(GL_VERSION));
 
     gs->renderer = renderer_type->new_renderer();


### PR DESCRIPTION
This allows building without thirdparty/glxw-sdl on Linux.